### PR TITLE
Rewrite the CocoaPods spec files, to declare the correct Public Headers for libwebp, fix the import issue when using `use_frameworks`

### DIFF
--- a/libwebp.podspec
+++ b/libwebp.podspec
@@ -19,9 +19,42 @@ Pod::Spec.new do |s|
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_ROOT}/libwebp/ ${PODS_TARGET_SRCROOT}/'
   }
   s.preserve_path = 'src'
+  s.default_subspecs = 'dec', 'enc', 'demux', 'mux'
 
-  s.source_files = 'src/webp/*.{h,c}', 'src/utils/*.{h,c}', 'src/dsp/*.{h,c}', 'src/enc/*.{h,c}', 'src/dec/*.{h,c}', 'src/demux/*.{h,c}', 'src/mux/*.{h,c}'
-  s.public_header_files = 'src/webp/*.h'
+  # common code, used by actual subspecs
+  s.subspec 'core' do |ss|
+    ss.source_files = 'src/utils/*.{h,c}', 'src/dsp/*.{h,c}', 'src/webp/types.h', 'src/webp/format_constants.h'
+    ss.public_header_files = 'src/webp/types.h', 'src/webp/format_constants.h'
+  end
+
+  # webp decoding
+  s.subspec 'dec' do |ss|
+    ss.dependency 'libwebp/core'
+    ss.source_files = 'src/dec/*.{h,c}', 'src/webp/decode.h'
+    ss.public_header_files = 'src/webp/decode.h'
+  end
+
+  # webp encoding
+  s.subspec 'enc' do |ss|
+    ss.dependency 'libwebp/core'
+    ss.source_files = 'src/enc/*.{h,c}', 'src/webp/encode.h'
+    ss.public_header_files = 'src/webp/encode.h'
+  end
+
+  # animated webp decoding
+  s.subspec 'demux' do |ss|
+    ss.dependency 'libwebp/dec'
+    ss.source_files = 'src/demux/*.{h,c}', 'src/webp/demux.h', 'src/webp/mux_types.h'
+    ss.public_header_files = 'src/webp/demux.h', 'src/webp/mux_types.h'
+  end
+
+  # animated webp encoding
+  s.subspec 'mux' do |ss|
+    ss.dependency 'libwebp/enc'
+    ss.dependency 'libwebp/demux'
+    ss.source_files = 'src/mux/*.{h,c}', 'src/webp/mux.h'
+    ss.public_header_files = 'src/webp/mux.h'
+  end
 
   # fix #include <inttypes.h> cause 'Include of non-modular header inside framework module error'
   s.prepare_command = <<-CMD

--- a/libwebp.podspec
+++ b/libwebp.podspec
@@ -19,38 +19,23 @@ Pod::Spec.new do |s|
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_ROOT}/libwebp/ ${PODS_TARGET_SRCROOT}/'
   }
   s.preserve_path = 'src'
-  s.default_subspecs = 'dec', 'enc', 'demux', 'mux'
+  s.default_subspecs = 'webp', 'demux', 'mux'
 
-  # common code, used by actual subspecs
-  s.subspec 'core' do |ss|
-    ss.source_files = 'src/utils/*.{h,c}', 'src/dsp/*.{h,c}', 'src/webp/types.h', 'src/webp/format_constants.h'
-    ss.public_header_files = 'src/webp/types.h', 'src/webp/format_constants.h'
-  end
-
-  # webp decoding
-  s.subspec 'dec' do |ss|
-    ss.dependency 'libwebp/core'
-    ss.source_files = 'src/dec/*.{h,c}', 'src/webp/decode.h'
-    ss.public_header_files = 'src/webp/decode.h'
-  end
-
-  # webp encoding
-  s.subspec 'enc' do |ss|
-    ss.dependency 'libwebp/core'
-    ss.source_files = 'src/enc/*.{h,c}', 'src/webp/encode.h'
-    ss.public_header_files = 'src/webp/encode.h'
+  # webp decoding && encoding
+  s.subspec 'webp' do |ss|
+    ss.source_files = 'src/webp/decode.h', 'src/webp/encode.h', 'src/webp/types.h', 'src/webp/mux_types.h', 'src/webp/format_constants.h', 'src/utils/*.{h,c}', 'src/dsp/*.{h,c}', 'src/dec/*.{h,c}', 'src/enc/*.{h,c}'
+    ss.public_header_files = 'src/webp/decode.h', 'src/webp/encode.h', 'src/webp/types.h', 'src/webp/mux_types.h', 'src/webp/format_constants.h'
   end
 
   # animated webp decoding
   s.subspec 'demux' do |ss|
-    ss.dependency 'libwebp/dec'
-    ss.source_files = 'src/demux/*.{h,c}', 'src/webp/demux.h', 'src/webp/mux_types.h'
-    ss.public_header_files = 'src/webp/demux.h', 'src/webp/mux_types.h'
+    ss.dependency 'libwebp/webp'
+    ss.source_files = 'src/demux/*.{h,c}', 'src/webp/demux.h'
+    ss.public_header_files = 'src/webp/demux.h'
   end
 
   # animated webp encoding
   s.subspec 'mux' do |ss|
-    ss.dependency 'libwebp/enc'
     ss.dependency 'libwebp/demux'
     ss.source_files = 'src/mux/*.{h,c}', 'src/webp/mux.h'
     ss.public_header_files = 'src/webp/mux.h'

--- a/libwebp.podspec
+++ b/libwebp.podspec
@@ -15,48 +15,16 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
-  s.pod_target_xcconfig = {
-    'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_ROOT}/libwebp/**'
+  s.xcconfig = {
+    'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_ROOT}/libwebp/ ${PODS_TARGET_SRCROOT}/'
   }
+  s.preserve_path = 'src'
 
-  s.subspec 'webp' do |ss|
-    ss.header_dir = 'webp'
-    ss.source_files = 'src/webp/*.h'
-  end
+  s.source_files = 'src/webp/*.{h,c}', 'src/utils/*.{h,c}', 'src/dsp/*.{h,c}', 'src/enc/*.{h,c}', 'src/dec/*.{h,c}', 'src/demux/*.{h,c}', 'src/mux/*.{h,c}'
+  s.public_header_files = 'src/webp/*.h'
 
-  s.subspec 'core' do |ss|
-    ss.source_files = [
-      'src/utils/*.{h,c}',
-      'src/dsp/*.{h,c}',
-      'src/enc/*.{h,c}',
-      'src/dec/*.{h,c}'
-    ]
-    ss.dependency 'libwebp/webp'
-  end
-
-  s.subspec 'utils' do |ss|
-    ss.dependency 'libwebp/core'
-  end
-
-  s.subspec 'dsp' do |ss|
-    ss.dependency 'libwebp/core'
-  end
-
-  s.subspec 'enc' do |ss|
-    ss.dependency 'libwebp/core'
-  end
-
-  s.subspec 'dec' do |ss|
-    ss.dependency 'libwebp/core'
-  end
-
-  s.subspec 'demux' do |ss|
-    ss.source_files = 'src/demux/*.{h,c}'
-    ss.dependency 'libwebp/core'
-  end
-
-  s.subspec 'mux' do |ss|
-    ss.source_files = 'src/mux/*.{h,c}'
-    ss.dependency 'libwebp/core'
-  end
+  # fix #include <inttypes.h> cause 'Include of non-modular header inside framework module error'
+  s.prepare_command = <<-CMD
+                      sed -i.bak 's/<inttypes.h>/<stdint.h>/g' './src/webp/types.h'
+                      CMD
 end

--- a/libwebp.podspec
+++ b/libwebp.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_ROOT}/libwebp/ ${PODS_TARGET_SRCROOT}/'
   }
   s.preserve_path = 'src'


### PR DESCRIPTION
### Podspec structure issue
Current libwebp.podspec, using this subspec to declare headers:

```
  s.subspec 'dsp' do |ss|	
    ss.dependency 'libwebp/core'	
  end
```

I guess the reason is that you want to help to solve this source code import in libwebp

```
#include "src/dsp/dsp.h"
```

However, it's useless. The correct and easy way to do so, just keep the original `src` folder structure. We have Podspec syntax `s.preserve_path ` for this.


### Umbrella header
And, curernt libwebp does not works for `use_frameworks!` and using this code to import

```
@import SDWebImage;
// Swift
import SDWebImage
```

Because the umbrella headers generated by CocoaPods, include all the private headers, which have their own macro to detect whether or not to import. For example, `neon.h` only can be include when build on arm64 device. This should not be exported to public.

So this PR, fix all this problem, and keep compatible with current [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder). And works for `use_frameworks!` and Swift.

![image](https://user-images.githubusercontent.com/6919743/59245782-b3980b80-8c4c-11e9-95cc-7c9808d3a708.png)
