### PR TITLE
Fix the libwebp SwiftPM include issue. Now using the same strcture to enerate public header search path, which make the user easy to use like `<webp/decode.h>`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,9 @@ let package = Package(
         .target(
             name: "libwebp",
             dependencies: [],
-            path: "libwebp/src",
-            publicHeadersPath: "webp",
-            cSettings: [.headerSearchPath("../")])
+            path: "libwebp",
+            sources: ["src"],
+            publicHeadersPath: "src",
+            cSettings: [.headerSearchPath(".")])
     ]
 )


### PR DESCRIPTION
This allows the user to use 

```c
#include <webp/decode.h>
```

instead of 

```c
#include "decode.h"
```